### PR TITLE
Supressed warning spam.  Obsolete messages RE: ApiAsync most iffy, other...

### DIFF
--- a/Source/Facebook/Facebook-Net40.csproj
+++ b/Source/Facebook/Facebook-Net40.csproj
@@ -34,7 +34,7 @@
     <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_DYNAMIC;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_REFLECTIONEMIT;FLUENTHTTP_URLENCODING;FLUENTHTTP_HTMLENCODING;TPL;FLUENTHTTP_CORE_TPL;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CustomRules.ruleset</CodeAnalysisRuleSet>
     <CodeContractsEnableRuntimeChecking>False</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
@@ -59,8 +59,9 @@
     <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
     <CodeContractsReferenceAssembly>%28none%29</CodeContractsReferenceAssembly>
     <CodeContractsContainerAnalysis>True</CodeContractsContainerAnalysis>
-    <DocumentationFile>..\..\Bin\Debug\net40-client\Facebook.xml</DocumentationFile>
+    <DocumentationFile>..\..\Bin\Debug\net40-client\Facebook.XML</DocumentationFile>
     <CodeContractsCacheAnalysisResults>True</CodeContractsCacheAnalysisResults>
+    <NoWarn>1591,1587</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Source/Facebook/FacebookClient.Async.Tasks.cs
+++ b/Source/Facebook/FacebookClient.Async.Tasks.cs
@@ -16,6 +16,8 @@
 // <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
 // <website>https://github.com/facebook-csharp-sdk/facbook-csharp-sdk</website>
 //-----------------------------------------------------------------------
+// TODO: Renable obsolete messages (disable because of warning noise - the ApiAsync doesn't actually seem that obsolete)
+#pragma warning disable 612, 618
 
 namespace Facebook
 {

--- a/Source/Facebook/FacebookClient.Async.cs
+++ b/Source/Facebook/FacebookClient.Async.cs
@@ -17,6 +17,9 @@
 // <website>https://github.com/facebook-csharp-sdk/facbook-csharp-sdk</website>
 //-----------------------------------------------------------------------
 
+// TODO: Renable obsolete messages (disable because of warning noise - the ApiAsync doesn't actually seem that obsolete)
+#pragma warning disable 612, 618
+
 namespace Facebook
 {
     using System;

--- a/Source/Facebook/Properties/AssemblyInfo.cs
+++ b/Source/Facebook/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright 2011")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("6.0.5.0")]
-[assembly: AssemblyFileVersion("6.0.5-alpha")]
+[assembly: AssemblyFileVersion("6.0.5.1")]
 

--- a/Source/Facebook/SimpleJson.cs
+++ b/Source/Facebook/SimpleJson.cs
@@ -569,6 +569,7 @@ namespace Facebook
         /// Converts a IDictionary&lt;string,object> / IList&lt;object> object into a JSON string
         /// </summary>
         /// <param name="json">A IDictionary&lt;string,object> / IList&lt;object></param>
+        /// <param name="jsonSerializerStrategy">Serializer strategy to use</param>
         /// <returns>A JSON encoded string, or null if object 'json' is not serializable</returns>
         public static string SerializeObject(object json, IJsonSerializerStrategy jsonSerializerStrategy)
         {


### PR DESCRIPTION
Compiling with source, there are way to many warnings to work with the Sdk as a dependency project.
So I suppressed the warning spam in the 4.0 project.  Obsolete messages RE: ApiAsync most iffy and close to "real" warnings, others are just xml document warnings and code analysis disagreeing with your design choices.

There are two files I used pragma disable in for the obsolete messages, though using the TODO: marker so at least they will appear in Visual Studio's task list.

I suggest a warnings pass when enabling the code analysis rules _then_ submitting it with either the warnings fixed or the rules suppressed where necessary.

I personally treat warnings more like errors... so find it pretty difficult to work with all those yellow lights there.  Especially when working with my own code.

I realise you may not agree with any of the above - but consider the impression you leave with a developer who just started to look at the project and how alarming over a hundred warnings might be.
