### PR TITLE
Added an Interface to FacebookClient

### DIFF
--- a/Source/Facebook/Facebook-Net35.csproj
+++ b/Source/Facebook/Facebook-Net35.csproj
@@ -148,6 +148,13 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Sync.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
+    <Compile Include="IFacebookClient.SignedRequest.cs" />
+    <Compile Include="IFacebookClient.Sync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Source/Facebook/Facebook-Net40.csproj
+++ b/Source/Facebook/Facebook-Net40.csproj
@@ -156,6 +156,15 @@
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />
     <Compile Include="HttpWebRequestCreatedEventArgs.cs" />
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Sync.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
+    <Compile Include="IFacebookClient.SignedRequest.cs" />
+    <Compile Include="IFacebookClient.Sync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Source/Facebook/Facebook-Net45.csproj
+++ b/Source/Facebook/Facebook-Net45.csproj
@@ -158,6 +158,14 @@
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />
     <Compile Include="HttpWebRequestCreatedEventArgs.cs" />
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Sync.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
+    <Compile Include="IFacebookClient.SignedRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Source/Facebook/Facebook-SL5.csproj
+++ b/Source/Facebook/Facebook-SL5.csproj
@@ -163,6 +163,13 @@
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />
     <Compile Include="HttpWebRequestCreatedEventArgs.cs" />
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
+    <Compile Include="IFacebookClient.SignedRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Source/Facebook/Facebook-WP7.csproj
+++ b/Source/Facebook/Facebook-WP7.csproj
@@ -147,6 +147,11 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.SignedRequest.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>

--- a/Source/Facebook/Facebook-WinRT.csproj
+++ b/Source/Facebook/Facebook-WinRT.csproj
@@ -73,6 +73,12 @@
     <Compile Include="FacebookUploadProgressChangedEventArgs.cs">
       <DependentUpon>FacebookApiEventArgs.cs</DependentUpon>
     </Compile>
+    <Compile Include="IFacebookClient.Async.cs" />
+    <Compile Include="IFacebookClient.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.cs" />
+    <Compile Include="IFacebookClient.Batch.Async.Tasks.cs" />
+    <Compile Include="IFacebookClient.cs" />
+    <Compile Include="IFacebookClient.OAuthResult.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HttpHelper.cs" />
     <Compile Include="HttpMethod.cs" />

--- a/Source/Facebook/FacebookClient.Async.Tasks.cs
+++ b/Source/Facebook/FacebookClient.Async.Tasks.cs
@@ -24,7 +24,7 @@ namespace Facebook
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         /// <summary>
         /// Makes an asynchronous request to the Facebook server.

--- a/Source/Facebook/FacebookClient.Async.cs
+++ b/Source/Facebook/FacebookClient.Async.cs
@@ -32,7 +32,7 @@ namespace Facebook
     using System.Net;
 
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         private HttpWebRequestWrapper _httpWebRequest;
         private object _httpWebRequestLocker = new object();

--- a/Source/Facebook/FacebookClient.Batch.Async.Tasks.cs
+++ b/Source/Facebook/FacebookClient.Batch.Async.Tasks.cs
@@ -22,7 +22,7 @@ namespace Facebook
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         /// <summary>
         /// Makes an asynchronous batch request to the Facebook server.

--- a/Source/Facebook/FacebookClient.Batch.Async.cs
+++ b/Source/Facebook/FacebookClient.Batch.Async.cs
@@ -27,7 +27,7 @@ namespace Facebook
     using System.Linq;
     using System.Text;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         private const string AtLeastOneBatchParameterRequried = "At least one batch parameter is required";
         private const string OnlyOneAttachmentAllowedPerBatchRequest = "Only one attachement (FacebookMediaObject/FacebookMediaStream) allowed per FacebookBatchParamter.";

--- a/Source/Facebook/FacebookClient.Batch.Sync.cs
+++ b/Source/Facebook/FacebookClient.Batch.Sync.cs
@@ -19,7 +19,7 @@
 
 namespace Facebook
 {
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         /// <summary>
         /// Makes a batch request to the Facebook server.

--- a/Source/Facebook/FacebookClient.OAuthResult.cs
+++ b/Source/Facebook/FacebookClient.OAuthResult.cs
@@ -24,7 +24,7 @@ namespace Facebook
     using System.Diagnostics.CodeAnalysis;
     using System.Text;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         /// <summary>
         /// Try parsing the url to <see cref="FacebookOAuthResult"/>.

--- a/Source/Facebook/FacebookClient.SignedRequest.cs
+++ b/Source/Facebook/FacebookClient.SignedRequest.cs
@@ -26,7 +26,7 @@ namespace Facebook
     using System.Text;
     using System.Diagnostics.CodeAnalysis;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         private const string InvalidSignedRequest = "Invalid signed_request";
 

--- a/Source/Facebook/FacebookClient.Sync.cs
+++ b/Source/Facebook/FacebookClient.Sync.cs
@@ -25,7 +25,7 @@ namespace Facebook
     using System.IO;
     using System.Net;
 
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         /// <summary>
         /// Makes a request to the Facebook server.

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -36,7 +36,7 @@ namespace Facebook
     /// <summary>
     /// Provides access to the Facbook Platform.
     /// </summary>
-    public partial class FacebookClient
+    public partial class FacebookClient : IFacebookClient
     {
         private const int BufferSize = 1024 * 4; // 4kb
         private const string AttachmentMustHavePropertiesSetError = "Attachment (FacebookMediaObject/FacebookMediaStream) must have a content type, file name, and value set.";

--- a/Source/Facebook/IFacebookClient.Async.Tasks.cs
+++ b/Source/Facebook/IFacebookClient.Async.Tasks.cs
@@ -1,0 +1,26 @@
+﻿namespace Facebook
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public partial interface IFacebookClient
+    {
+#if ASYNC_AWAIT
+		Task<object> ApiTaskAsync(HttpMethod httpMethod, string path, object parameters, Type resultType, object userState, CancellationToken cancellationToken);
+#endif
+		Task<object> GetTaskAsync(string path);
+		Task<object> GetTaskAsync(object parameters);
+		Task<object> GetTaskAsync(string path, object parameters);
+		Task<object> GetTaskAsync(string path, object parameters, CancellationToken cancellationToken);
+		Task<object> PostTaskAsync(object parameters);
+		Task<object> PostTaskAsync(string path, object parameters);
+		Task<object> PostTaskAsync(string path, object parameters, CancellationToken cancellationToken);
+		Task<object> PostTaskAsync(string path, object parameters, object userState, CancellationToken cancellationToken);
+#if ASYNC_AWAIT
+		Task<object> PostTaskAsync(string path, object parameters, object userState, CancellationToken cancellationToken, IProgress<FacebookUploadProgressChangedEventArgs> uploadProgress);
+#endif
+		Task<object> DeleteTaskAsync(string path);
+		Task<object> DeleteTaskAsync(string path, object parameters, CancellationToken cancellationToken);
+    }
+}

--- a/Source/Facebook/IFacebookClient.Async.cs
+++ b/Source/Facebook/IFacebookClient.Async.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Facebook
+{
+    public partial interface IFacebookClient
+    {
+		event EventHandler<FacebookApiEventArgs> GetCompleted;
+		event EventHandler<FacebookApiEventArgs> PostCompleted;
+		event EventHandler<FacebookApiEventArgs> DeleteCompleted;
+		event EventHandler<FacebookUploadProgressChangedEventArgs> UploadProgressChanged;
+		void CancelAsync();
+		void GetAsync(string path);
+		void GetAsync(object parameters);
+		void GetAsync(string path, object parameters);
+		void GetAsync(string path, object parameters, object userState);
+		void PostAsync(object parameters);
+		void PostAsync(string path, object parameters);
+		void PostAsync(string path, object parameters, object userState);
+		void DeleteAsync(string path);
+		void DeleteAsync(string path, object parameters, object userState);
+    }
+}

--- a/Source/Facebook/IFacebookClient.Batch.Async.Tasks.cs
+++ b/Source/Facebook/IFacebookClient.Batch.Async.Tasks.cs
@@ -1,0 +1,24 @@
+﻿namespace Facebook
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public partial interface IFacebookClient
+    {
+        Task<object> BatchTaskAsync(params FacebookBatchParameter[] batchParameters);
+        Task<object> BatchTaskAsync(FacebookBatchParameter[] batchParameters, object userState, CancellationToken cancellationToken
+#if ASYNC_AWAIT
+, System.IProgress<FacebookUploadProgressChangedEventArgs> uploadProgress
+#endif
+);
+        Task<object> BatchTaskAsync(FacebookBatchParameter[] batchParameters, object userState, object parameters, CancellationToken cancellationToken
+#if ASYNC_AWAIT
+, System.IProgress<FacebookUploadProgressChangedEventArgs> uploadProgress
+#endif
+);
+#if ASYNC_AWAIT
+		Task<object> BatchTaskAsync(FacebookBatchParameter[] batchParameters, object userToken, CancellationToken cancellationToken);
+		Task<object> BatchTaskAsync(FacebookBatchParameter[] batchParameters, object userToken, object parameters, CancellationToken cancellationToken);
+#endif
+    }
+}

--- a/Source/Facebook/IFacebookClient.Batch.Async.cs
+++ b/Source/Facebook/IFacebookClient.Batch.Async.cs
@@ -1,0 +1,9 @@
+﻿namespace Facebook
+{
+    public partial interface IFacebookClient
+    {
+        void BatchAsync(FacebookBatchParameter[] batchParameters, object userState, object parameters);
+        void BatchAsync(FacebookBatchParameter[] batchParameters, object userState);
+        void BatchAsync(FacebookBatchParameter[] batchParameters);
+    }
+}

--- a/Source/Facebook/IFacebookClient.Batch.Sync.cs
+++ b/Source/Facebook/IFacebookClient.Batch.Sync.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Facebook
+{
+    public partial interface IFacebookClient
+    {
+        object Batch(params FacebookBatchParameter[] batchParameters);
+        object Batch(FacebookBatchParameter[] batchParameters, object parameters);
+    }
+}

--- a/Source/Facebook/IFacebookClient.OAuthResult.cs
+++ b/Source/Facebook/IFacebookClient.OAuthResult.cs
@@ -1,0 +1,12 @@
+﻿namespace Facebook
+{
+    using System;
+
+    public partial interface IFacebookClient
+    {
+        bool TryParseOAuthCallbackUrl(Uri url, out FacebookOAuthResult facebookOAuthResult);
+        FacebookOAuthResult ParseOAuthCallbackUrl(Uri uri);
+        Uri GetLoginUrl(object parameters);
+        Uri GetLogoutUrl(object parameters);
+    }
+}

--- a/Source/Facebook/IFacebookClient.SignedRequest.cs
+++ b/Source/Facebook/IFacebookClient.SignedRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace Facebook
+{
+    public partial interface IFacebookClient
+    {
+		bool TryParseSignedRequest(string appSecret, string signedRequestValue, out object signedRequest);
+		bool TryParseSignedRequest(string signedRequestValue, out object signedRequest);
+		object ParseSignedRequest(string appSecret, string signedRequestValue);
+		object ParseSignedRequest(string signedRequestValue);
+    }
+}

--- a/Source/Facebook/IFacebookClient.Sync.cs
+++ b/Source/Facebook/IFacebookClient.Sync.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Facebook
+{
+    public partial interface IFacebookClient
+    {
+		object Get(string path);
+		object Get(object parameters);
+		object Get(string path, object parameters);
+		object Post(object parameters);
+		object Post(string path, object parameters);
+		object Delete(string path);
+		object Delete(string path, object parameters);
+    }
+}

--- a/Source/Facebook/IFacebookClient.cs
+++ b/Source/Facebook/IFacebookClient.cs
@@ -1,0 +1,21 @@
+﻿
+namespace Facebook
+{
+    using System;
+
+    public partial interface IFacebookClient
+    {
+        string AccessToken { get; set; }
+        string AppId { get; set; }
+        string AppSecret { get; set; }
+        bool IsSecureConnection { get; set; }
+        bool UseFacebookBeta { get; set; }
+        Func<object, string> SerializeJson { get; set; }
+        Func<string, Type, object> DeserializeJson { get; set; }
+        Func<Uri, HttpWebRequestWrapper> HttpWebRequestFactory { get; set; }
+#if false
+		static void SetDefaultJsonSerializers(Func<object, string> jsonSerializer, Func<string, Type, object> jsonDeserializer)
+		static void SetDefaultHttpWebRequestFactory(Func<Uri, HttpWebRequestWrapper> httpWebRequestFactory)
+#endif
+    }
+}


### PR DESCRIPTION
I created the following files:
- IFacebookClient.Async.cs
- IFacebookClient.Async.Tasks.cs
- IFacebookClient.Batch.Async.cs
- IFacebookClient.Batch.Async.Tasks.cs
- IFacebookClient.Batch.Sync.cs
- IFacebookClient.cs
- IFacebookClient.OAuthResult.cs
- IFacebookClient.SignedRequest.cs
- IFacebookClient.Sync.cs

I then modified the following to implement the IFacebookClient
- FacebookClient.Async.cs
- FacebookClient.Async.Tasks.cs
- FacebookClient.Batch.Async.cs
- FacebookClient.Batch.Async.Tasks.cs
- FacebookClient.Batch.Sync.cs
- FacebookClient.cs
- FacebookClient.OAuthResult.cs
- FacebookClient.SignedRequest.cs
- FacebookClient.Sync.cs

I modifed the following projects to include the new files:
- Facebook-Net35.csproj
- Facebook-Net40.csproj
- Facebook-Net45.csproj
- Facebook-SL5.csproj
- Facebook-WinRT.csproj
- Facebook-WP7.csproj

All compile via rake except WP7. This generates the following error:

"C:\SpiderMonkeyTech\CSharp\facebook-csharp-sdk\Source\Facebook-WP7.sln" (Build
 target) (1) ->
"C:\SpiderMonkeyTech\CSharp\facebook-csharp-sdk\Source\Facebook\Facebook-WP7.cs
proj" (default target) (2) ->
(CoreCompile target) ->
  HttpHelper.cs(1320,22): error CS0234: The type or namespace name 'HttpUtility
' does not exist in the namespace 'System.Net' (are you missing an assembly ref
erence?) [C:\SpiderMonkeyTech\CSharp\facebook-csharp-sdk\Source\Facebook\Facebo
ok-WP7.csproj]
  HttpHelper.cs(1732,22): error CS0234: The type or namespace name 'HttpUtility
' does not exist in the namespace 'System.Net' (are you missing an assembly ref
erence?) [C:\SpiderMonkeyTech\CSharp\facebook-csharp-sdk\Source\Facebook\Facebo
ok-WP7.csproj]

All 49 test pass running rake build:tests 
