### PR TITLE
Static default serializers

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -244,7 +244,7 @@ namespace Facebook
         }
 
         /// <summary>
-        /// Gets the default json serializer.
+        /// Gets or sets the default json serializer.
         /// </summary>
         /// <returns>
         /// The default json serializer.
@@ -256,7 +256,20 @@ namespace Facebook
             set { _defaultJsonSerializer = value ?? SimpleJson.SerializeObject; }
         }
 
-            /// <summary>
+        /// <summary>
+        /// Gets or sets the default json deserializer.
+        /// </summary>
+        /// <returns>
+        /// The default json deserializer.
+        /// </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Func<string, Type, object> DefaultJsonDeserializer
+        {
+            get { return _defaultJsonDeserializer; }
+            set { _defaultJsonDeserializer = value ?? SimpleJson.DeserializeObject; }
+        }
+
+        /// <summary>
         /// Sets the default http web request factory.
         /// </summary>
         /// <param name="httpWebRequestFactory"></param>


### PR DESCRIPTION
PR for #175.

You can get or set the default JsonSerializers/Deserializers without creating new instance of FacebookClient using these new static properties.

```
Func<object, string> serializer = FacebookClient.DefaultJsonSerializer();
Func<string, Type, object> deserializer = FacebookClient.DefaultJsonDeserializer();
```

This allows users to use the internal FB C# SDK's SimpleJson without adding SimpleJson package incase they already have Facebook.dll referenced.
