### PR TITLE
Use custom DeserializeJson for text/plain /oauth/access_token results also

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -606,7 +606,7 @@ namespace Facebook
                             if (body.ContainsKey("expires"))
                                 body["expires"] = Convert.ToInt64(body["expires"], CultureInfo.InvariantCulture);
 
-                            result = resultType == null ? body : DeserializeJson(body.ToString(), resultType);
+                            result = DeserializeJson(body.ToString(), resultType);
 
                             return result;
                         }


### PR DESCRIPTION
It is possible to setup own DeserializeJson method.

It should be used everywhere, for /oauth/access_token result also - as otherwise it might be that the client does not expect to receive JsonObject created by SimpleJson - and wants its own data (which might be just a simple string, for example, if client has its own JSON parser).
