### PR TITLE
Fixes signing of the Windows Store SDK

### DIFF
--- a/Source/Facebook/Facebook-WindowsStore.csproj
+++ b/Source/Facebook/Facebook-WindowsStore.csproj
@@ -36,6 +36,12 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\Win8\Facebook.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\SharedKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
   </ItemGroup>


### PR DESCRIPTION
Other versions of the Facebook C# SDK are signed, but for some reason the Windows Store one is not.  This prevents other signed applications/libraries from being able to use the Facebook C# SDK for Windows 8 apps.
