### PR TITLE
Instance set http web request factory

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -194,6 +194,7 @@ namespace Facebook
         /// Http web request factory.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SetHttpWebRequestFactory.")]
         public virtual Func<Uri, HttpWebRequestWrapper> HttpWebRequestFactory
         {
             get { return _httpWebRequestFactory; }


### PR DESCRIPTION
added

``` c#
public virtual void SetHttpWebRequestFactory(Func<Uri, HttpWebRequestWrapper> httpWebRequestFactory)
```

Marked `HttpWebRequestFactory` instance property as obsolete. Since this is a breaking change we should remove it in future version. There are quite a number of users using this method for timeout, proxy and unit test scenarios.
