### PR TITLE
Instance set json serializers

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -175,6 +175,8 @@ namespace Facebook
         /// <summary>
         /// Serialize object to json.
         /// </summary>
+        [Obsolete("Use SetJsonSerializers")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Func<object, string> SerializeJson
         {
             get { return _serializeJson ?? (_serializeJson = _defaultJsonSerializer); }
@@ -184,6 +186,8 @@ namespace Facebook
         /// <summary>
         /// Deserialize json to object.
         /// </summary>
+        [Obsolete("Use SetJsonSerializers")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Func<string, Type, object> DeserializeJson
         {
             get { return _deserializeJson; }


### PR DESCRIPTION
PR for #207

marked `SerializeJson` and `DeserializeJson` instance properties as obsolete and set `[EditorBrowsable(EditorBrowsableState.Never)]` attribute.

added 

``` c#
public virtual void SetJsonSerializers(Func<object, string> jsonSerializer, Func<string, Type, object> jsonDeserializer)
```
