### PR TITLE
removed algorithm check during ParseSignedRequest

### DIFF
--- a/Source/Facebook/FacebookClient.SignedRequest.cs
+++ b/Source/Facebook/FacebookClient.SignedRequest.cs
@@ -95,10 +95,7 @@ namespace Facebook
                 throw new InvalidOperationException(InvalidSignedRequest);
 
             var base64UrlDecoded = Base64UrlDecode(encodedEnvelope);
-            var envelope = (IDictionary<string, object>)DeserializeJson(Encoding.UTF8.GetString(base64UrlDecoded, 0, base64UrlDecoded.Length), null);
-            var algorithm = (string)envelope["algorithm"];
-            if (!algorithm.Equals("HMAC-SHA256"))
-                throw new InvalidOperationException("Unknown algorithm. Expected HMAC-SHA256");
+            var envelope = DeserializeJson(Encoding.UTF8.GetString(base64UrlDecoded, 0, base64UrlDecoded.Length), null);
 
             byte[] key = Encoding.UTF8.GetBytes(appSecret);
             byte[] digest = ComputeHmacSha256Hash(Encoding.UTF8.GetBytes(encodedEnvelope), key);


### PR DESCRIPTION
- ParseSignedRequest now works with both SimpleJson and JSON.NET and does not depend on `IDictionary<string,object>`.
- Can use `JObject` from json.net. does not force the use of JsonObject.
- Unlike #229 does not require double deserialization.
