### PR TITLE
Added Timeout property to the FacebookClient

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -595,11 +595,12 @@ namespace Facebook
 
             request.TrySetUserAgent("Facebook C# SDK");
 
+#if !WINDOWS_PHONE
             if (Timeout.HasValue)
             {
                 request.Timeout = Timeout.Value;
             }
-
+#endif
             return new HttpHelper(request);
         }
 


### PR DESCRIPTION
added int? Timeout property to the FacebookClient so that if it's not set (null) the default timeout will work (100s)
