### PR TITLE
Adding the missing file for GetLoginUrl and ParseOAuthCallbackUrl

### DIFF
--- a/Source/Facebook/Facebook-Universal-8.1.csproj
+++ b/Source/Facebook/Facebook-Universal-8.1.csproj
@@ -52,6 +52,7 @@
     <Compile Include="FacebookClient.Batch.Async.cs" />
     <Compile Include="FacebookClient.Batch.Async.Tasks.cs" />
     <Compile Include="FacebookClient.cs" />
+    <Compile Include="FacebookClient.OAuthResult.cs" />
     <Compile Include="FacebookMediaObject.cs" />
     <Compile Include="FacebookMediaStream.cs" />
     <Compile Include="FacebookOAuthException.cs" />


### PR DESCRIPTION
@prabirshrestha Verified that this resolves GetLoginUrl and ParseOAuthCallbackUrl in both Universal Win 8.1 and WP 8.1. Please merge
