### PR TITLE
Graph API versioning support

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -115,6 +115,9 @@ namespace Facebook
         private bool _isSecureConnection;
         private bool _useFacebookBeta;
 
+        private string _version;
+        private static string _defaultVersion;
+
         private Func<object, string> _serializeJson;
         private static Func<object, string> _defaultJsonSerializer;
 
@@ -173,6 +176,24 @@ namespace Facebook
         }
 
         /// <summary>
+        /// Get or sets the graph api version to use.
+        /// </summary>
+        public virtual string Version
+        {
+            get { return _version; }
+            set { _version = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the default graph api version to use when initializing a new instance of <see cref="FacebookClient"/>.
+        /// </summary>
+        public static string DefaultVersion
+        {
+            get { return _defaultVersion; }
+            set { _defaultVersion = value; }
+        }
+
+        /// <summary>
         /// Serialize object to json.
         /// </summary>
         [Obsolete("Use SetJsonSerializers")]
@@ -218,6 +239,7 @@ namespace Facebook
         /// </summary>
         public FacebookClient()
         {
+            _version = _defaultVersion;
             _deserializeJson = _defaultJsonDeserializer;
             _httpWebRequestFactory = _defaultHttpWebRequestFactory;
         }
@@ -306,8 +328,9 @@ namespace Facebook
             }
 
             Uri uri;
-            bool isLegacyRestApi = false;
-            path = ParseUrlQueryString(path, parametersWithoutMediaObjects, false, out uri, out isLegacyRestApi);
+            bool isLegacyRestApi;
+            bool isAbsolutePath;
+            path = ParseUrlQueryString(path, parametersWithoutMediaObjects, false, out uri, out isLegacyRestApi, out isAbsolutePath);
 
             if (parametersWithoutMediaObjects.ContainsKey("format"))
                 parametersWithoutMediaObjects["format"] = "json-strings";
@@ -414,7 +437,14 @@ namespace Facebook
                 uriBuilder = new UriBuilder { Host = uri.Host, Scheme = uri.Scheme };
             }
 
-            uriBuilder.Path = path;
+            if (isAbsolutePath || string.IsNullOrEmpty(Version))
+            {
+                uriBuilder.Path = path;
+            }
+            else
+            {
+                uriBuilder.Path = Version + "/" + path;
+            }
 
             string contentType = null;
             long? contentLength = null;
@@ -923,15 +953,17 @@ namespace Facebook
             return sb.ToString();
         }
 
-        private static string ParseUrlQueryString(string path, IDictionary<string, object> parameters, bool forceParseAllUrls, out Uri uri, out bool isLegacyRestApi)
+        private static string ParseUrlQueryString(string path, IDictionary<string, object> parameters, bool forceParseAllUrls, out Uri uri, out bool isLegacyRestApi, out bool isAbsolutePath)
         {
             if (parameters == null)
                 throw new ArgumentNullException("parameters");
 
             isLegacyRestApi = false;
+            isAbsolutePath = false;
             uri = null;
             if (Uri.TryCreate(path, UriKind.Absolute, out uri))
             {
+                isAbsolutePath = true;
                 if (forceParseAllUrls)
                 {
                     path = string.Concat(uri.AbsolutePath, uri.Query);
@@ -1027,7 +1059,8 @@ namespace Facebook
         {
             Uri uri;
             bool isLegacyRestApi;
-            return ParseUrlQueryString(path, parameters, forceParseAllUrls, out uri, out isLegacyRestApi);
+            bool isAbsolutePath;
+            return ParseUrlQueryString(path, parameters, forceParseAllUrls, out uri, out isLegacyRestApi, out isAbsolutePath);
         }
     }
 }


### PR DESCRIPTION
This doesn't include versioning for GetLoginUrl.

PR for #294

Since this is not a breaking change, anyone using v6.x should be able to update safely to this version.

By default it will not use any versioning. You need to set the `DefaultVersion` or `Version` to use versioning.

Usage:

**Set the default version for all instances of new `FacebookClient`.**

This will make a request using v2.1

``` c#
FacebookClient.DefaultVersion = "v2.1";
var fb = new FacebookClient();
dynamic result = fb.Get("me");
Console.WriteLine(result);  
```

**Override default version**

This will make a request using v2.0

``` c#
FacebookClient.DefaultVersion = "v2.1";
var fb = new FacebookClient();
fb.Version = "v2.0";
dynamic result = fb.Get("me");
Console.WriteLine(result);  
```

**Disable default versioning for a particular instance**

This will make a request without any version.

``` c#
FacebookClient.DefaultVersion = "v2.1";
var fb = new FacebookClient();
fb.Version = null;
dynamic result = fb.Get("me");
Console.WriteLine(result);  
```

**GOTCHAS**

**If full absolute url is given, `DefaultVersion` and `Version` property will be ignored**

The below code will use version 2.3.

``` c#
FacebookClient.DefaultVersion = "v2.1";
var fb = new FacebookClient();
fb.Version = "v2.0";
dynamic result = fb.Get("https://graph.facebook.com/v2.3/me");
Console.WriteLine(result);  
```

**Do not add version to path if `Version` property is set**

This will be an invalid request as the url will be http://graph.facebook.com/v2.0/v2.0/me

``` c#
var fb = new FacebookClient();
fb.Version = "v2.0";
dynamic result = fb.Get("v2.0/me");
Console.WriteLine(result);  
```

For more information on versioning refer to https://developers.facebook.com/docs/apps/versions
