### PR TITLE
Added additional Facebook error message

### DIFF
--- a/Source/Facebook/FacebookApiException.cs
+++ b/Source/Facebook/FacebookApiException.cs
@@ -80,10 +80,12 @@ namespace Facebook
         /// <param name="errorType">Type of the error.</param>
         /// <param name="errorCode">Code of the error.</param>
         /// <param name="errorSubcode">Subcode of the error.</param>
-        public FacebookApiException(string message, string errorType, int errorCode, int errorSubcode)
+        public FacebookApiException(string message, string errorType, int errorCode, int errorSubcode, string errorUserTitle, string errorUserMsg)
             : this(message, errorType, errorCode)
         {
             ErrorSubcode = errorSubcode;
+            ErrorUserTitle = errorUserTitle;
+            ErrorUserMsg = errorUserMsg;
         }
 
         /// <summary>
@@ -127,5 +129,9 @@ namespace Facebook
         /// </summary>
         /// <value>The code of the error subcode.</value>
         public int ErrorSubcode { get; set; }
+
+        public string ErrorUserTitle { get; set; }
+
+        public string ErrorUserMsg { get; set; }
     }
 }

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -756,8 +756,6 @@ namespace Facebook
                 {
                     var errorType = error["type"] as string;
                     var errorMessage = error["message"] as string;
-                    var errorUserTitle = error["error_user_title"] as string;
-                    var errorUserMsg = error["error_user_msg"] as string;
                     int errorCode = 0;
 
                     if (error.ContainsKey("code"))
@@ -766,6 +764,18 @@ namespace Facebook
                     var errorSubcode = 0;
                     if (error.ContainsKey("error_subcode"))
                         int.TryParse(error["error_subcode"].ToString(), out errorSubcode);
+
+                    var errorUserTitle = string.Empty;
+                    if (error.ContainsKey("error_user_title"))
+                    {
+                        errorUserTitle = error["error_user_title"].ToString();
+                    }
+
+                    var errorUserMsg = string.Empty;
+                    if (error.ContainsKey("error_user_msg"))
+                    {
+                        errorUserMsg = error["error_user_msg"].ToString();
+                    }
 
                     // Check to make sure the correct data is in the response
                     if (!string.IsNullOrEmpty(errorType) && !string.IsNullOrEmpty(errorMessage))

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -756,6 +756,8 @@ namespace Facebook
                 {
                     var errorType = error["type"] as string;
                     var errorMessage = error["message"] as string;
+                    var errorUserTitle = error["error_user_title"] as string;
+                    var errorUserMsg = error["error_user_msg"] as string;
                     int errorCode = 0;
 
                     if (error.ContainsKey("code"))
@@ -771,11 +773,11 @@ namespace Facebook
                         // We don't include the inner exception because it is not needed and is always a WebException.
                         // It is easier to understand the error if we use Facebook's error message.
                         if (errorType == "OAuthException")
-                            resultException = new FacebookOAuthException(errorMessage, errorType, errorCode, errorSubcode);
+                            resultException = new FacebookOAuthException(errorMessage, errorType, errorCode, errorSubcode, errorUserTitle, errorUserMsg);
                         else if (errorType == "API_EC_TOO_MANY_CALLS" || (errorMessage.Contains("request limit reached")))
                             resultException = new FacebookApiLimitException(errorMessage, errorType);
                         else
-                            resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode);
+                            resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode, errorUserTitle, errorUserMsg);
                     }
                 }
                 else

--- a/Source/Facebook/FacebookOAuthException.cs
+++ b/Source/Facebook/FacebookOAuthException.cs
@@ -74,8 +74,8 @@ namespace Facebook
         /// <param name="errorType">Type of the error.</param>
         /// <param name="errorCode">Code of the error.</param>
         /// <param name="errorSubcode">Subcode of the error.</param>
-        public FacebookOAuthException(string message, string errorType, int errorCode, int errorSubcode)
-            : base(message, errorType, errorCode, errorSubcode)
+        public FacebookOAuthException(string message, string errorType, int errorCode, int errorSubcode, string errorUserTitle, string errorUserMsg)
+            : base(message, errorType, errorCode, errorSubcode, errorUserTitle, errorUserMsg)
         {
         }
 


### PR DESCRIPTION
It seems Facebook has made some changes with the latest version of the api and the useful user error messages are now in error_user_msg.  I have added this it the Exception object so they can be displayed.