### PR TITLE
updated GetDialogUrl to support versioning

### DIFF
--- a/Source/Facebook/FacebookClient.OAuthResult.cs
+++ b/Source/Facebook/FacebookClient.OAuthResult.cs
@@ -153,7 +153,13 @@ namespace Facebook
             }
 
             var sb = new StringBuilder();
-            sb.AppendFormat(isMobile ? "https://m.facebook.com/dialog/{0}?" : "https://www.facebook.com/dialog/{0}?", dialog);
+            sb.AppendFormat(isMobile ? "https://m.facebook.com/" : "https://www.facebook.com/");
+            if (!string.IsNullOrEmpty(Version))
+            {
+                sb.AppendFormat("{0}/", Version);
+            }
+
+            sb.AppendFormat("dialog/{0}?", dialog);
 
             foreach (var kvp in dictionary)
                 sb.AppendFormat("{0}={1}&", HttpHelper.UrlEncode(kvp.Key), HttpHelper.UrlEncode(BuildHttpQuery(kvp.Value, HttpHelper.UrlEncode)));


### PR DESCRIPTION
PR for #294

Follow up for #311

Since this is not a breaking change, anyone using v6.x should be able to update safely to this version.

By default it will not use any versioning. You need to set the `DefaultVersion` or `Version` to use versioning.

**Example without versioning:**

```c#
var fb = new FacebookClient();
var loginParameters = new Dictionary<string, object>();
loginParameters["client_id"] = "clientId";
loginParameters["client_secret"] = "clientSecret";
loginParameters["response_type"] = "code";
loginParameters["redirect_uri"] = "https://www.facebook.com/connect/login_success.html";

var url = fb.GetLoginUrl(loginParameters);
```

Url doesn't contain version number.

```
https://www.facebook.com/dialog/oauth?client_id=clientId&client_secret=clientSecret&response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html
```

**Example with versioning:**

```c#
var fb = new FacebookClient();
fb.Version = "v2.0";
var loginParameters = new Dictionary<string, object>();
loginParameters["client_id"] = "clientId";
loginParameters["client_secret"] = "clientSecret";
loginParameters["response_type"] = "code";
loginParameters["redirect_uri"] = "https://www.facebook.com/connect/login_success.html";

var url = fb.GetLoginUrl(loginParameters);
```

Url doesn't contain version number.

```
https://www.facebook.com/v2.0/dialog/oauth?client_id=clientId&client_secret=clientSecret&response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html
```

For more information on versioning refer to https://developers.facebook.com/docs/apps/versions