### PR TITLE
Fixed: HttpHelper.UrlEncode didn't encode long strings.

### DIFF
--- a/Source/Facebook.Tests/HttpHelperTests.cs
+++ b/Source/Facebook.Tests/HttpHelperTests.cs
@@ -9,7 +9,7 @@ namespace Facebook.Tests
         public class UrlEncodeTests
         {
             [Fact]
-            public void UrlEncodeTest()
+            public void UrlEncodeDoesNotThrow()
             {
                 var sb = new StringBuilder();
                 for (int i = 0; i <= 100000; i++)
@@ -17,6 +17,38 @@ namespace Facebook.Tests
                     sb.Append("a");
                 }
                 Assert.DoesNotThrow(() => HttpHelper.UrlEncode(sb.ToString()));
+            }
+
+            [Fact]
+            public void UrlEncodeEncodes1000Chars()
+            {
+                var charCount = 1000;
+
+                UrlEncodeEncodes(charCount);
+            }
+
+            [Fact]
+            public void UrlEncodeEncodesMoreThan1000Chars()
+            {
+                var charCount = 10001;
+
+                UrlEncodeEncodes(charCount);
+            }
+
+            private void UrlEncodeEncodes(int charCount)
+            {
+                var sb = new StringBuilder(charCount);
+                var sbVerification = new StringBuilder(3 * charCount);
+
+                for (int i = 0; i < charCount; i++)
+                {
+                    sb.Append("/");
+                    sbVerification.Append("%2F");
+                }
+
+                var result = HttpHelper.UrlEncode(sb.ToString());
+
+                Assert.True(sbVerification.ToString().Equals(result, StringComparison.InvariantCultureIgnoreCase));
             }
 
             [Fact]

--- a/Source/Facebook/HttpHelper.cs
+++ b/Source/Facebook/HttpHelper.cs
@@ -1318,7 +1318,7 @@ namespace Facebook
                     ? Uri.EscapeDataString(s.Substring(MAX_LIMIT*i, MAX_LIMIT))
                     : Uri.EscapeDataString(s.Substring(MAX_LIMIT*i)));
             }
-            return s;
+            return sb.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed: HttpHelper.UrlEncode didn't encode strings, which were longer than 1000 characters.