### PR TITLE
Added ErrorUserTitle and ErrorUserMsg (fixes #330, #318)

### DIFF
--- a/Source/Facebook/FacebookApiException.cs
+++ b/Source/Facebook/FacebookApiException.cs
@@ -127,5 +127,15 @@ namespace Facebook
         /// </summary>
         /// <value>The code of the error subcode.</value>
         public int ErrorSubcode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error user title.
+        /// </summary>
+        public string ErrorUserTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error user message.
+        /// </summary>
+        public string ErrorUserMsg { get; set; }
     }
 }

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -795,6 +795,14 @@ namespace Facebook
                     if (error.ContainsKey("error_subcode"))
                         int.TryParse(error["error_subcode"].ToString(), out errorSubcode);
 
+                    string errorUserTitle = null;
+                    if (error.ContainsKey("error_user_title"))
+                        errorUserTitle = (string)error["error_user_title"];
+
+                    string errorUserMsg = null;
+                    if (error.ContainsKey("error_user_title"))
+                        errorUserMsg = (string)error["error_user_title"];
+
                     // Check to make sure the correct data is in the response
                     if (!string.IsNullOrEmpty(errorType) && !string.IsNullOrEmpty(errorMessage))
                     {
@@ -807,6 +815,9 @@ namespace Facebook
                         else
                             resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode);
                     }
+
+                    resultException.ErrorUserTitle = errorUserTitle;
+                    resultException.ErrorUserMsg = errorUserMsg;
                 }
                 else
                 {


### PR DESCRIPTION
fixes #330, #318.

Support for `ErrorUserTitle` and `ErrorUserMsg` (https://developers.facebook.com/docs/graph-api/using-graph-api/v2.1)

```json
 {
       "error": {
         "message": "Message describing the error", 
         "type": "OAuthException", 
         "code": 190,
         "error_subcode": 460,
         "error_user_title": "A title",
         "error_user_msg": "A message"
       }
     }
```