### PR TITLE
Fix #336: FacebookClient throws NullReferenceException when calling GetTaskAsync in Windows 10 app 

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -602,10 +602,8 @@ namespace Facebook
                     throw new ArgumentOutOfRangeException("httpMethod");
             }
 
-            if (contentType != null)
-            {
+            if (!string.IsNullOrEmpty(contentType))
                 request.ContentType = contentType;
-            }
 
             if (!string.IsNullOrEmpty(etag))
                 request.Headers[HttpRequestHeader.IfNoneMatch] = string.Concat('"', etag, '"');

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -602,7 +602,10 @@ namespace Facebook
                     throw new ArgumentOutOfRangeException("httpMethod");
             }
 
-            request.ContentType = contentType;
+            if (contentType != null)
+            {
+                request.ContentType = contentType;
+            }
 
             if (!string.IsNullOrEmpty(etag))
                 request.Headers[HttpRequestHeader.IfNoneMatch] = string.Concat('"', etag, '"');


### PR DESCRIPTION
 null value is assigned to HttpWebRequest.ContentType, which causes a NullReferenceException.