### PR TITLE
NRE fixed for ContentType on Windows 10

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -602,7 +602,10 @@ namespace Facebook
                     throw new ArgumentOutOfRangeException("httpMethod");
             }
 
-            request.ContentType = contentType;
+            if (contentType != null)
+            {
+                request.ContentType = contentType;
+            }
 
             if (!string.IsNullOrEmpty(etag))
                 request.Headers[HttpRequestHeader.IfNoneMatch] = string.Concat('"', etag, '"');


### PR DESCRIPTION
Setting ContentType to null in Windows 10 (Tech Preview; Build 10069) leads to NRE.
This change fixes it.