### PR TITLE
Support user addition to Audience and forcing form data content type …

### DIFF
--- a/Source/Facebook.Tests/Facebook.Tests.csproj
+++ b/Source/Facebook.Tests/Facebook.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -74,6 +75,7 @@
   <ItemGroup>
     <Compile Include="DateTimeConverterTests.cs" />
     <Compile Include="DummyIntegrationTests.cs" />
+    <Compile Include="FacebookClientTests\AudienceTests.cs" />
     <Compile Include="FacebookClientTests\ConstructorTests.cs" />
     <Compile Include="FacebookClientTests\GetDialogUrlTests.cs" />
     <Compile Include="FacebookClientTests\ParseSignedRequestTests.cs" />
@@ -107,6 +109,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Facebook.Tests/FacebookClientTests/AudienceTests.cs
+++ b/Source/Facebook.Tests/FacebookClientTests/AudienceTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Facebook.Tests.FacebookClientTests
+{
+    using Facebook;
+    using Xunit;
+
+    public class AudienceTests
+    {
+        public readonly FacebookClient _fb = new FacebookClient();
+
+        [Fact]
+        public void TheUserAdditionToAudienceWorks()
+        {
+            var audienceId = 6025792497450;
+            var accessToken = "your_access_token";
+            var payload = @"{ 
+                    'schema': 'EMAIL_SHA256', 
+                    'data': [   'HASH1', 'HASH2' ] }";
+            _fb.ForceMultipartFormData = true;
+
+            var parameters = new Dictionary<string, object>();
+            parameters["payload"] =  payload;
+            _fb.AccessToken = accessToken;
+            var result = _fb.Post(string.Format("{0}/users", audienceId), parameters);
+            Assert.Equal(((dynamic)result).num_received, 2);
+        }
+    }
+}

--- a/Source/Facebook.Tests/packages.config
+++ b/Source/Facebook.Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="StatLight" version="1.6.4375" />
   <package id="xunit" version="1.9.0.1566" />
   <package id="xunit.extensions" version="1.9.0.1566" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
   <package id="xunit.runners" version="1.9.0.1566" />
 </packages>

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -127,6 +127,7 @@ namespace Facebook
         private Func<Uri, HttpWebRequestWrapper> _httpWebRequestFactory;
         private static Func<Uri, HttpWebRequestWrapper> _defaultHttpWebRequestFactory;
 
+        private bool _forceMultipartFormData;
         /// <remarks>For unit testing</remarks>
         internal Func<string> Boundary { get; set; }
 
@@ -224,6 +225,12 @@ namespace Facebook
         {
             get { return _httpWebRequestFactory; }
             set { _httpWebRequestFactory = value ?? (_httpWebRequestFactory = _defaultHttpWebRequestFactory); }
+        }
+
+        public bool ForceMultipartFormData
+        {
+            get { return _forceMultipartFormData; }
+            set { _forceMultipartFormData = value; }
         }
 
         /// <summary>
@@ -479,7 +486,7 @@ namespace Facebook
             }
             else
             {
-                if (mediaObjects.Count == 0 && mediaStreams.Count == 0)
+                if (mediaObjects.Count == 0 && mediaStreams.Count == 0 && !ForceMultipartFormData)
                 {
                     contentType = "application/x-www-form-urlencoded";
                     var sb = new StringBuilder();


### PR DESCRIPTION
…in general.

Unit test added for audiences.
VS12 xUnit runner NuGet package dependency added.

Main API change:
Added ForceMultipartFormData to FacebookClient.
Note that this can affect some asyncronous (maybe, as I did not dive into the code)
and multithreaded accesses to the FacebookClient.
You may want to try and expand the signature of the Post methods, I simply did not have the time for it.
Anyhow, this is a backward compatible fix in a sense that it won't affect anyone who does not set this field,
nor those who do but create a new client per request.

You may want to refactor afterwords given the comments above.
As you understand, I needed a quick fix and decided many people may benefit from it even if it may not be perfect.
Thanks for your great work,

Boris