### PR TITLE
FacebookApiException doesn't pass extra information

### DIFF
--- a/Source/Facebook/FacebookApiException.cs
+++ b/Source/Facebook/FacebookApiException.cs
@@ -17,6 +17,8 @@
 // <website>https://github.com/facebook-csharp-sdk/facbook-csharp-sdk</website>
 //-----------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Facebook
 {
     using System;
@@ -137,5 +139,15 @@ namespace Facebook
         /// Gets or sets the error user message.
         /// </summary>
         public string ErrorUserMsg { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag indicating whether the error is known to be transient or permanent.
+        /// </summary>
+        public bool? IsTransient { get; set; }
+
+        /// <summary>
+        /// Gets or sets the original error response, to allow users to extract custom information.
+        /// </summary>
+        public IDictionary<string, object> ErrorResponse { get; set; }
     }
 }

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -804,18 +804,15 @@ namespace Facebook
                     if (error.ContainsKey("error_user_msg"))
                         errorUserMsg = (string)error["error_user_msg"];
 
-                    // Check to make sure the correct data is in the response
-                    if (!string.IsNullOrEmpty(errorType) && !string.IsNullOrEmpty(errorMessage))
-                    {
-                        // We don't include the inner exception because it is not needed and is always a WebException.
-                        // It is easier to understand the error if we use Facebook's error message.
-                        if (errorType == "OAuthException")
-                            resultException = new FacebookOAuthException(errorMessage, errorType, errorCode, errorSubcode);
-                        else if (errorType == "API_EC_TOO_MANY_CALLS" || (errorMessage.Contains("request limit reached")))
-                            resultException = new FacebookApiLimitException(errorMessage, errorType);
-                        else
-                            resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode);
-                    }
+                    // We don't include the inner exception because it is not needed and is always a WebException.
+                    // It is easier to understand the error if we use Facebook's error message.
+                    if (errorType == "OAuthException" || errorCode == 102 || errorCode == 190)
+                        resultException = new FacebookOAuthException(errorMessage, errorType, errorCode, errorSubcode);
+                    else if (errorType == "API_EC_TOO_MANY_CALLS" || errorCode == 4 || errorCode == 17
+                        || (null != errorMessage && errorMessage.Contains("request limit reached")))
+                        resultException = new FacebookApiLimitException(errorMessage, errorType);
+                    else
+                        resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode);
 
                     if (!resultException.IsTransient.HasValue)
                     {

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -817,6 +817,22 @@ namespace Facebook
                             resultException = new FacebookApiException(errorMessage, errorType, errorCode, errorSubcode);
                     }
 
+                    if (!resultException.IsTransient.HasValue)
+                    {
+                        object objValue;
+                        if (error.TryGetValue("is_transient", out objValue))
+                        {
+                            resultException.IsTransient = objValue as bool?;
+                            if (!resultException.IsTransient.HasValue)
+                            {
+                                bool boolValue;
+                                if (bool.TryParse(objValue.ToString(), out boolValue))
+                                    resultException.IsTransient = boolValue;
+                            }
+                        }
+                    }
+
+                    resultException.ErrorResponse = error;
                     resultException.ErrorUserTitle = errorUserTitle;
                     resultException.ErrorUserMsg = errorUserMsg;
                 }


### PR DESCRIPTION
In particular, FB might provide information on whether the error is permanent or transient, add extra error_data fields to explain the nature of the problem etc. Currently, this information is not passed to the user and makes it hard to determine whether the request can be retried as-is, or to log a more detailed explanation for subsequent triage.