### PR TITLE
Option for FacebookClient to always return the response headers

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -118,6 +118,9 @@ namespace Facebook
         private string _version;
         private static string _defaultVersion;
 
+        private bool _alwaysReturnHeaders;
+        private static bool _defaultAlwaysReturnHeaders;
+
         private Func<object, string> _serializeJson;
         private static Func<object, string> _defaultJsonSerializer;
 
@@ -194,6 +197,24 @@ namespace Facebook
         }
 
         /// <summary>
+        /// Gets or sets whether the response headers for an API request should be returned in addition to the body
+        /// </summary>
+        public bool AlwaysReturnHeaders
+        {
+            get { return _alwaysReturnHeaders; }
+            set { _alwaysReturnHeaders = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the default value for AlwaysReturnHeaders to use when initializing a new instance of <see cref="FacebookClient"/> 
+        /// </summary>
+        public static bool DefaultAlwaysReturnHeaders
+        {
+            get { return _defaultAlwaysReturnHeaders; }
+            set { _defaultAlwaysReturnHeaders = value; }
+        }
+
+        /// <summary>
         /// Serialize object to json.
         /// </summary>
         [Obsolete("Use SetJsonSerializers")]
@@ -241,6 +262,7 @@ namespace Facebook
         {
             _version = _defaultVersion;
             _deserializeJson = _defaultJsonDeserializer;
+            _alwaysReturnHeaders = _defaultAlwaysReturnHeaders;
             _httpWebRequestFactory = _defaultHttpWebRequestFactory;
         }
 
@@ -686,7 +708,7 @@ namespace Facebook
 
                 if (exception == null)
                 {
-                    if (containsEtag && httpHelper != null)
+                    if ((containsEtag || _alwaysReturnHeaders) && httpHelper != null)
                     {
                         var json = new JsonObject();
                         var response = httpHelper.HttpWebResponse;


### PR DESCRIPTION
This PR adds an option for `FacebookClient` to always return the response headers in addition to the body.
Currently the response headers will be returned if the request contains ETags, but headers may always be required, even without any ETags in the request, e.g. for tracking request rate limits.