### PR TITLE
Fix the last segment upload fail by commenting out the line 541 that was breaking. 

### DIFF
--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -538,7 +538,7 @@ namespace Facebook
                         indexOfDisposableStreams.Add(streams.Count);
                         streams.Add(new MemoryStream(fileData));
                         indexOfDisposableStreams.Add(streams.Count);
-                        streams.Add(new MemoryStream(Encoding.UTF8.GetBytes(MultiPartNewLine)));
+                        //streams.Add(new MemoryStream(Encoding.UTF8.GetBytes(MultiPartNewLine)));
                     }
 
                     foreach (var facebookMediaStream in mediaStreams)

--- a/Source/Facebook/FacebookClient.cs
+++ b/Source/Facebook/FacebookClient.cs
@@ -538,7 +538,6 @@ namespace Facebook
                         indexOfDisposableStreams.Add(streams.Count);
                         streams.Add(new MemoryStream(fileData));
                         indexOfDisposableStreams.Add(streams.Count);
-                        //streams.Add(new MemoryStream(Encoding.UTF8.GetBytes(MultiPartNewLine)));
                     }
 
                     foreach (var facebookMediaStream in mediaStreams)


### PR DESCRIPTION
This line creates the issue where the last segment of a video file fails to upload and gives your various OAuth error. Got the solution from stackoverflow. I have to give credit to johnwa111. Thank you. I am just doing what you suggested. 
https://stackoverflow.com/questions/54145847/facebook-advideo-upload-with-video-file-chunk-is-giving-exception